### PR TITLE
Fix voting api to not discard older burn transactions

### DIFF
--- a/keyserver/src/pubsub/handlers.rs
+++ b/keyserver/src/pubsub/handlers.rs
@@ -173,7 +173,7 @@ pub async fn put_message(
     if existing_value.is_ok() && message.payload.len() == 0 {
         let mut wrapper = existing_value.unwrap();
         // Dedupe transactions
-        for transaction in &message.transactions {
+        for transaction in &wrapper.transactions {
             let tx = Transaction::decode(&mut transaction.tx.as_slice())
                 .map_err(MessagesRpcRejection::TransactionInvalidError)?;
             let idx = transaction.index;


### PR DESCRIPTION
Currently, there is a bug where all old burn transactions are replaced.
However, this is not the desired behavior. This commit properly
consolidates burn transactions that were recorded with the new burn
transactions before saving the post back to the database. There is one
remaining issue in that this should occur within a RocksDB transaction.