### PR TITLE
Rename `IntoResponse` to `ToResponse`

### DIFF
--- a/keyserver/src/net/metadata/errors.rs
+++ b/keyserver/src/net/metadata/errors.rs
@@ -2,7 +2,7 @@ use cashweb::auth_wrapper::{ParseError, VerifyError};
 use thiserror::Error;
 use warp::reject::Reject;
 
-use crate::net::IntoResponse;
+use crate::net::ToResponse;
 
 #[derive(Debug, Error)]
 pub enum PutMetadataError {
@@ -22,7 +22,7 @@ impl From<rocksdb::Error> for PutMetadataError {
 
 impl Reject for PutMetadataError {}
 
-impl IntoResponse for PutMetadataError {
+impl ToResponse for PutMetadataError {
     fn to_status(&self) -> u16 {
         match self {
             Self::Database(_) => 500,
@@ -47,7 +47,7 @@ impl From<rocksdb::Error> for GetMetadataError {
     }
 }
 
-impl IntoResponse for GetMetadataError {
+impl ToResponse for GetMetadataError {
     fn to_status(&self) -> u16 {
         match self {
             Self::NotFound => 404,

--- a/keyserver/src/net/mod.rs
+++ b/keyserver/src/net/mod.rs
@@ -42,19 +42,19 @@ pub fn address_decode(addr_str: &str) -> Result<Address, AddressDecode> {
     Address::decode(&addr_str).map_err(|(cash_err, base58_err)| AddressDecode(cash_err, base58_err))
 }
 
-impl IntoResponse for AddressDecode {
+impl ToResponse for AddressDecode {
     fn to_status(&self) -> u16 {
         400
     }
 }
 
 /// Helper trait for converting errors into a response.
-pub trait IntoResponse: fmt::Display + Sized {
+pub trait ToResponse: fmt::Display + Sized {
     /// Convert error into a status code.
     fn to_status(&self) -> u16;
 
     /// Convert error into a `Response`.
-    fn into_response(&self) -> Response<Body> {
+    fn to_response(&self) -> Response<Body> {
         let status = self.to_status();
 
         if status != 500 {
@@ -75,27 +75,27 @@ pub trait IntoResponse: fmt::Display + Sized {
 pub async fn handle_rejection(err: Rejection) -> Result<Response<Body>, Infallible> {
     if let Some(err) = err.find::<AddressDecode>() {
         error!(message = "failed to decode address", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<GetMetadataError>() {
         error!(message = "failed to get metadata", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<PutMetadataError>() {
         error!(message = "failed to put metadata", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<PaymentError>() {
         error!(message = "payment failed", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<PeeringUnavailible>() {
         error!(message = "failed to get peers", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<ProtectionError>() {

--- a/keyserver/src/net/payments.rs
+++ b/keyserver/src/net/payments.rs
@@ -22,7 +22,7 @@ use warp::{
     reject::Reject,
 };
 
-use crate::{net::IntoResponse, METADATA_PATH, PAYMENTS_PATH, SETTINGS};
+use crate::{net::ToResponse, METADATA_PATH, PAYMENTS_PATH, SETTINGS};
 
 pub const COMMITMENT_PREIMAGE_SIZE: usize = 32 + 32;
 pub const COMMITMENT_SIZE: usize = 32;
@@ -48,7 +48,7 @@ pub enum PaymentError {
 
 impl Reject for PaymentError {}
 
-impl IntoResponse for PaymentError {
+impl ToResponse for PaymentError {
     fn to_status(&self) -> u16 {
         match self {
             Self::Address(_) => 400,

--- a/keyserver/src/net/peers.rs
+++ b/keyserver/src/net/peers.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 use warp::{http::Response, hyper::Body, reject::Reject};
 
-use crate::{net::IntoResponse, peering::PeerHandler, SETTINGS};
+use crate::{net::ToResponse, peering::PeerHandler, SETTINGS};
 
 #[derive(Debug, Error)]
 #[error("peering not supported")]
@@ -9,7 +9,7 @@ pub struct PeeringUnavailible;
 
 impl Reject for PeeringUnavailible {}
 
-impl IntoResponse for PeeringUnavailible {
+impl ToResponse for PeeringUnavailible {
     fn to_status(&self) -> u16 {
         501
     }

--- a/relayserver/src/net/messages.rs
+++ b/relayserver/src/net/messages.rs
@@ -21,7 +21,7 @@ use warp::{http::Response, hyper::Body, reject::Reject};
 
 use crate::{
     db::{self, Database},
-    net::{ws::MessageBus, IntoResponse},
+    net::{ws::MessageBus, ToResponse},
     SETTINGS,
 };
 
@@ -68,7 +68,7 @@ impl From<rocksdb::Error> for GetMessageError {
 
 impl Reject for GetMessageError {}
 
-impl IntoResponse for GetMessageError {
+impl ToResponse for GetMessageError {
     fn to_status(&self) -> u16 {
         match self {
             Self::DB(_) => 500,
@@ -248,7 +248,7 @@ impl From<rocksdb::Error> for PutMessageError {
 
 impl Reject for PutMessageError {}
 
-impl IntoResponse for PutMessageError {
+impl ToResponse for PutMessageError {
     fn to_status(&self) -> u16 {
         match self {
             Self::DB(_) => 500,

--- a/relayserver/src/net/mod.rs
+++ b/relayserver/src/net/mod.rs
@@ -47,16 +47,16 @@ pub fn address_decode(addr_str: &str) -> Result<Address, AddressDecode> {
     Ok(address)
 }
 
-impl IntoResponse for AddressDecode {
+impl ToResponse for AddressDecode {
     fn to_status(&self) -> u16 {
         400
     }
 }
 
-pub trait IntoResponse: fmt::Display + Sized {
+pub trait ToResponse: fmt::Display + Sized {
     fn to_status(&self) -> u16;
 
-    fn into_response(&self) -> Response<Body> {
+    fn to_response(&self) -> Response<Body> {
         let status = self.to_status();
 
         if status != 500 {
@@ -76,32 +76,32 @@ pub trait IntoResponse: fmt::Display + Sized {
 pub async fn handle_rejection(err: Rejection) -> Result<Response<Body>, Infallible> {
     if let Some(err) = err.find::<AddressDecode>() {
         error!(message = "failed to decode address", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<GetProfileError>() {
         error!(message = "failed to get profile", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<PutProfileError>() {
         error!(message = "failed to put profile", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<GetMessageError>() {
         error!(message = "failed to get messages", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<PutMessageError>() {
         error!(message = "failed to put messages", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<PaymentError>() {
         error!(message = "payment failed", error = %err);
-        return Ok(err.into_response());
+        return Ok(err.to_response());
     }
 
     if let Some(err) = err.find::<ProtectionError>() {

--- a/relayserver/src/net/payments.rs
+++ b/relayserver/src/net/payments.rs
@@ -26,7 +26,7 @@ use warp::{
     reject::Reject,
 };
 
-use crate::{net::IntoResponse, PAYMENTS_PATH, SETTINGS};
+use crate::{net::ToResponse, PAYMENTS_PATH, SETTINGS};
 
 pub type Wallet = wallet::Wallet<Vec<u8>, Output>;
 
@@ -46,7 +46,7 @@ pub enum PaymentError {
 
 impl Reject for PaymentError {}
 
-impl IntoResponse for PaymentError {
+impl ToResponse for PaymentError {
     fn to_status(&self) -> u16 {
         match self {
             PaymentError::Preprocess(err) => match err {

--- a/relayserver/src/net/profiles.rs
+++ b/relayserver/src/net/profiles.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use tokio::task;
 use warp::{http::Response, hyper::Body, reject::Reject};
 
-use crate::{db::Database, net::IntoResponse};
+use crate::{db::Database, net::ToResponse};
 
 #[derive(Debug, Error)]
 pub enum GetProfileError {
@@ -18,7 +18,7 @@ pub enum GetProfileError {
 
 impl Reject for GetProfileError {}
 
-impl IntoResponse for GetProfileError {
+impl ToResponse for GetProfileError {
     fn to_status(&self) -> u16 {
         match self {
             Self::NotFound => 404,
@@ -41,7 +41,7 @@ pub enum PutProfileError {
 
 impl Reject for PutProfileError {}
 
-impl IntoResponse for PutProfileError {
+impl ToResponse for PutProfileError {
     fn to_status(&self) -> u16 {
         match self {
             Self::Database(_) => 500,


### PR DESCRIPTION
"into" implies taking by value, but this trait only takes by reference. "to" is more apt in Rust parlance.